### PR TITLE
enable COOP/COEP

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -3,11 +3,12 @@
   Content-Security-Policy : default-src 'none'; connect-src 'self'; img-src 'self'; script-src 'self'; style-src 'self'; frame-src https://www.youtube-nocookie.com; form-action 'none'; frame-ancestors 'none'; block-all-mixed-content; base-uri 'none'
   X-Content-Type-Options : nosniff
   Referrer-Policy : no-referrer
-  # Cross-Origin-Opener-Policy : same-origin
   X-Frame-Options : DENY
   X-XSS-Protection : 0
   Permissions-Policy : accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), sync-xhr=(), xr-spatial-tracking=()
   Cross-Origin-Resource-Policy : same-origin
+  Cross-Origin-Opener-Policy : same-origin
+  Cross-Origin-Embedder-Policy : require-corp
 
 /*.xml
   Content-Security-Policy : default-src 'none'; img-src 'self' data: https://www.w3.org/; style-src 'self' 'unsafe-inline'; block-all-mixed-content; base-uri 'none'


### PR DESCRIPTION
- [ ] make it so embedded YouTube player doesn't break
- [ ] make sure it doesn't cause issues with Safari's COOP implementation (upstream bug?)

What was tried to narrow down the issue, but didn't fix the WebKit+COOP issue (https://github.com/PrivSec-dev/privsec.dev/issues/41):
- disabling CSP entirely (https://github.com/PrivSec-dev/privsec.dev/pull/42/commits/c8cab20853306c613ab4cf6c194d8032345057ee)