### PR TITLE
linux distros: link to DSA-1571

### DIFF
--- a/content/os/Choosing Your Desktop Linux Distribution.md
+++ b/content/os/Choosing Your Desktop Linux Distribution.md
@@ -13,7 +13,7 @@ You should choose a distribution which stays close to the stable upstream softwa
 
 For frozen distributions, package maintainers are expected to backport patches to fix vulnerabilities (Debian is one such [example](https://www.debian.org/security/faq#handling)) rather than bump the software to the “next version” released by the upstream developer. Some security fixes [do not](https://arxiv.org/abs/2105.14565) receive a [CVE](https://en.wikipedia.org/wiki/Common_Vulnerabilities_and_Exposures) (particularly less popular software) at all and therefore do not make it into the distribution with this patching model. As a result minor security fixes are sometimes held back until the next major release.
 
-In fact, in certain cases, there have been vulnerabilities introduced by Debian because of their patching process. [Bug 1633467](https://bugzilla.mozilla.org/show_bug.cgi?id=1633467) and [Bug 1679430](https://bugzilla.mozilla.org/show_bug.cgi?id=1679430) are examples of this.
+In fact, in certain cases, there have been vulnerabilities introduced by Debian because of their patching process. [Bug 1633467](https://bugzilla.mozilla.org/show_bug.cgi?id=1633467) and [DSA-1571](https://www.debian.org/security/2008/dsa-1571) are examples of this.
 
 ![Upstream / Distros Gap](/images/upstream-distros-gap.png)
 


### PR DESCRIPTION
The Release Cycle section shows how the classic patching process of distributions isn't always effective, and can even introduce additional bugs and vulnerabilities non present in the upstream project. The two linked examples, though, are not that insightful; the first one links to a double free caused by an erroneous bugfix backport, while the second shows a simple crash, but caused by a patch not relevant to the backport of patches but wrote by a Debian developer trying to port the library to another kernel. In short, the second linked bug has little to do with the issue described in the guide.

This small patch replaces the aforementioned Firefox bug report with the Debian Security Advisory 1571 (DSA-1571), describing a serious bug introduced in the OpenSSL crypto library by an incautious backport of a security fix, only present in Debian's OpenSSL package. In my opinion, it gives to the reader a clearer idea of what a partial backport can cause.