### PR TITLE
Multiple fixes to Linux posts

### DIFF
--- a/content/posts/linux/Choosing Your Desktop Linux Distribution.md
+++ b/content/posts/linux/Choosing Your Desktop Linux Distribution.md
@@ -44,7 +44,7 @@ For a secure system, you are also expected to have sufficient Linux knowledge to
 If you are experienced with Linux and wish to use an Arch-based distribution, you should use Arch Linux proper, not any of its derivatives. Here are some examples of why that is the case:
 
 - **Manjaro**: This distribution holds packages back for 2 weeks to make sure that their own changes do not break, not to make sure that upstream is stable. When AUR packages are used, they are often built against the latest [libraries](https://en.wikipedia.org/wiki/Library_(computing)) from Arch’s repositories.
-- **Garuda**: They use [Chaotic-AUR](https://aur.chaotic.cx/) which automatically and blindly compiles packages from the AUR. There is no verification process to make sure that the AUR packages don’t suffer from supply chain attacks. Beyond that, their official communication channels are also problematic, since they push for very bad security advice such as that [the user should keep secure boot off forever](https://t.me/garudalinux/292499) because it is somehow bad and evil.
+- **Garuda**: They use [Chaotic-AUR](https://aur.chaotic.cx/) which automatically and blindly compiles packages from the AUR. There is no verification process to make sure that the AUR packages don’t suffer from supply chain attacks. Beyond that, they promote incredibly bad advice in their official communication channels such as to [keep Secure Boot off](https://t.me/garudalinux/292499) because it is somehow bad and evil.
 
 ## Kicksecure
 

--- a/content/posts/linux/Choosing Your Desktop Linux Distribution.md
+++ b/content/posts/linux/Choosing Your Desktop Linux Distribution.md
@@ -44,7 +44,7 @@ For a secure system, you are also expected to have sufficient Linux knowledge to
 If you are experienced with Linux and wish to use an Arch-based distribution, you should use Arch Linux proper, not any of its derivatives. Here are some examples of why that is the case:
 
 - **Manjaro**: This distribution holds packages back for 2 weeks to make sure that their own changes do not break, not to make sure that upstream is stable. When AUR packages are used, they are often built against the latest [libraries](https://en.wikipedia.org/wiki/Library_(computing)) from Arch’s repositories.
-- **Garuda**: They use [Chaotic-AUR](https://aur.chaotic.cx/) which automatically and blindly compiles packages from the AUR. There is no verification process to make sure that the AUR packages don’t suffer from supply chain attacks.
+- **Garuda**: They use [Chaotic-AUR](https://aur.chaotic.cx/) which automatically and blindly compiles packages from the AUR. There is no verification process to make sure that the AUR packages don’t suffer from supply chain attacks. Beyond that, their official communication channels are also problematic, since they push for very bad security advice such as that [the user should keep secure boot off forever](https://t.me/garudalinux/292499) because it is somehow bad and evil.
 
 ## Kicksecure
 
@@ -90,7 +90,7 @@ You can refer to the video by [Adam Šamalík](https://twitter.com/adsamalik) li
 
 ### openSUSE Tumbleweed and MicroOS
 
-Fedora Workstation and Silverblue's European counterpart. These are rolling release, fast updating distributions with [transactional update](https://kubic.opensuse.org/blog/2018-04-04-transactionalupdates/) using [Btrfs](https://en.wikipedia.org/wiki/Btrfs) and [Snapper](https://en.opensuse.org/openSUSE:Snapper_Tutorial). 
+Fedora Workstation and Silverblue's European counterpart. These are rolling release, fast updating distributions with [transactional update](https://kubic.opensuse.org/blog/2018-04-04-transactionalupdates/) using [Btrfs](https://en.wikipedia.org/wiki/Btrfs) and [Snapper](https://en.opensuse.org/openSUSE:Snapper_Tutorial).
 
 [MicroOS](https://microos.opensuse.org/) has a much smaller base system than [Tumbleweed](https://get.opensuse.org/tumbleweed) and mounts the running BTRFS subvomumes as read-only (hence its name and why it is considered an immutable distribution). Currently, it is still in Beta so bugs are to be expected. Nevertheless, it is an awesome project.
 

--- a/content/posts/linux/Desktop-Linux-Hardening.md
+++ b/content/posts/linux/Desktop-Linux-Hardening.md
@@ -9,7 +9,7 @@ Linux is [not a secure desktop operating system](/posts/linux/linux-insecurities
 
 **Before we start...**
 
-Some of the sections will include mentions of unofficial builds of packages like linux&#8209;hardened, lkrg&#8209;akmod, hardened_malloc, and so on. These are not endorsements&nbsp;--- they are merely to show that you have options to easily obtain and update these packages. Using unofficial builds of packages means adding more parties to trust, and you have to evaluate whether it is worth doing so for the potential privacy/security benefits or not.
+Some of the sections will include mentions of unofficial builds of packages like linux&#8209;hardened, akmod, hardened_malloc, and so on. These are not endorsements&nbsp;--- they are merely to show that you have options to easily obtain and update these packages. Using unofficial builds of packages means adding more parties to trust, and you have to evaluate whether it is worth doing so for the potential privacy/security benefits or not.
 
 ![Fedora Tux](/images/fedora-tux.png)
 
@@ -18,6 +18,8 @@ Some of the sections will include mentions of unofficial builds of packages like
 ### Drive Encryption
 
 Most Linux distributions have an option within its installer for enabling LUKS full disk encryption. If this option isn't set at installation time, you will have to backup your data and re-install, as encryption is applied after [disk partitioning](https://en.wikipedia.org/wiki/Disk_partitioning) but before [filesystem](https://en.wikipedia.org/wiki/File_system) creation.
+
+By default, `cryptsetup` does not setup authenticated encryption. If you are configuring partitioning using the command line, you can enable integrity with the `--integrity` argument.
 
 ### Encrypted Swap
 
@@ -41,13 +43,6 @@ wifi.scan-rand-mac-address=yes
 [connection]
 wifi.cloned-mac-address=random
 ethernet.cloned-mac-address=random
-```
-
-Next, disable transient hostname management by adding the following to your `/etc/NetworkManager/conf.d/01-transient-hostname.conf`:
-
-```
-[main]
-hostname-mode=none
 ```
 
 Then, restart your NetworkManager service:
@@ -133,7 +128,7 @@ One caveat with Snap packages is that you only have control over the interfaces 
 
 ### Firejail
 
-{{< youtube id="N-Mso2bSr3o">}}
+{{< youtube id="uUEkHd60Zyo">}}
 
 [Firejail](https://firejail.wordpress.com/) is another method of sandboxing. As it is a large [setuid](https://en.wikipedia.org/wiki/Setuid) binary, it has a large attack surface which increase susceptibility to [privilege escalation vulnerabilities](https://en.wikipedia.org/wiki/Privilege_escalation). [Madaidan offers additional details on how Firejail can worsen the security of your device.](https://madaidans-insecurities.github.io/linux.html#firejail)
 
@@ -210,9 +205,7 @@ fwupdmgr update
 
 Some distributions like Debian do not have fwupd installed by default, so you should check for its existence on your system and install it if needed.
 
-Several graphical frontends integrate with fwupd to offer firmware updates (GNOME Software, KDE Discover, Snap Store, [GNOME Firmware](https://gitlab.gnome.org/World/gnome-firmware), Pop!\_OS Settings app). However, not all distributions offer this integration by default, so you should check your specific system and setup scheduled updates or update notifications using [systemd timers](https://wiki.archlinux.org/title/systemd/Timers) or [cron](https://wiki.archlinux.org/title/Cron) if needed.
-
-Note that fwupd, like Windows Update, supports updating the UEFI. Power loss or forced shutdown in the middle of a UEFI update can brick your system, so unattended UEFI updating is not recommended unless you have the means to recover from a corrupted UEFI (motherboard flashback functionality or EEPROM flashing tools). fwupd UEFI updates can be disabled by adding `uefi_capsule` to `DisabledPlugins` in `/etc/fwupd/daemon.conf` and then restarting the fwupd daemon (`sudo systemctl restart fwupd`). **Keeping your UEFI up&#8209;to&#8209;date is important for security patches, so make sure to periodically revert this setting and apply updates manually or install UEFI updates via other methods supported by some motherboards.**
+Several graphical frontends integrate with fwupd to offer firmware updates (GNOME Software, KDE Discover, Snap Store, [GNOME Firmware](https://gitlab.gnome.org/World/gnome-firmware), Pop!\_OS Settings app). However, not all distributions offer this integration by default, so you should check your specific system and setup scheduled update notifications using [systemd timers](https://wiki.archlinux.org/title/systemd/Timers) or [cron](https://wiki.archlinux.org/title/Cron) if needed.
 
 ### Firewall
 
@@ -342,20 +335,6 @@ Disabling access to `/sys` without a proper whitelist will lead to various appli
 Some distributions like Arch Linux offer the [linux&#8209;hardened](https://github.com/anthraxx/linux-hardened) kernel package. It includes [hardening patches](https://wiki.archlinux.org/title/security#Kernel_hardening) and more security-conscious defaults.
 
 linux&#8209;hardened has unprivileged user namespaces (`kernel.unprivileged_userns_clone`) disabled by default. [This may impact some software.](#runtime-kernel-parameters-sysctl)
-
-#### Linux Kernel Runtime Guard (LKRG)
-
-LKRG is a kernel module which self&#8209;describes as a runtime kernel integrity checker and exploit detector:
-
-> As controversial as this concept is, LKRG attempts to _post_&#8209;detect and _hopefully_ promptly respond to unauthorized modifications to the running Linux kernel (integrity checking) or to credentials such as user IDs of the running processes (exploit detection). For process credentials, LKRG attempts to detect the exploit and take action before the kernel would grant access (such as open a file) based on the unauthorized credentials.
->
-> LKRG defeats many pre-existing exploits of Linux kernel vulnerabilities, and will likely defeat many future exploits (including of yet unknown vulnerabilities) that do not specifically attempt to bypass LKRG. While LKRG is _bypassable by design_, such bypasses tend to require more complicated and/or less reliable exploits.
-
-_(From [LKRG - Linux Kernel Runtime Guard](https://lkrg.org).)_
-
-If you can get LKRG and maintain module updates, it provides a worthwhile improvement to security.
-
-Debian-based distributions can get the LKRG DKMS package [from Kicksecure](https://www.kicksecure.com/wiki/Linux_Kernel_Runtime_Guard_LKRG), though Kicksecure does not install it by default. Packaging for Fedora is available through a [Copr repository](https://copr.fedorainfracloud.org/coprs/fepitre/lkrg/) maintained by Qubes OS developer fepitre. Arch users can obtain the LKRG DKMS package [from the AUR](https://aur.archlinux.org/packages/lkrg-dkms).
 
 #### grsecurity
 

--- a/content/posts/linux/NetworkManager Trackability Reduction.md
+++ b/content/posts/linux/NetworkManager Trackability Reduction.md
@@ -103,19 +103,6 @@ sudo hostnamectl hostname "localhost"
 
 An empty (blank) hostname is also an option, but a static hostname of "localhost" is less likely to cause breakage. Both will result in no hostname being broadcasted to the DHCP server.
 
-### Disabling transient hostname management {#rmhostname-transient}
-
-It's best to create a dedicated configuration file, such as `/etc/NetworkManager/conf.d/01-transient-hostname.conf`, to ensure package updates do not overwrite the configuration:
-
-```
-[main]
-hostname-mode=none
-```
-
-This will prevent NetworkManager from setting transient hostnames that may be provided by some DHCP servers. This will have no visible effect except with an empty static hostname.
-
-After editing the file, run `sudo nmcli general reload conf` to apply the new configuration. Run `sudo hostnamectl --transient hostname ""` to reset the transient hostname.
-
 ---
 
 ## Disable sending hostname to DHCP server


### PR DESCRIPTION
- Fix Firejail video URL
- Mention that Garuda also gives out some bad advices in the official channels (secure boot = restricted boot = bad)
- Remove disabling transient hostname since it is irrelevant to tracking reduction
- Remove LKRG (badness enumeration, performance penalty, bypassable, not being an official package on most repos)
- Brief mention of cryptsetup --integrity
- Remove unncessary and bad fwupd advice