### PR TITLE
Change to dropbear-initramfs

### DIFF
--- a/content/posts/linux/Using Native ZFS Encryption with Proxmox.md
+++ b/content/posts/linux/Using Native ZFS Encryption with Proxmox.md
@@ -115,15 +115,15 @@ systemctl enable zfs-load-key
 
 It is not convenient to type in the encryption password on the console. You might want to setup Dropbear inside of the initramfs to unlock the drive over SSH instead.
 
-First, install the `dropbear` package. Note that we are passing the `--no-install-recommends` argument here, as we don't want it to install `cryptsetup` and give annoying warnings on every initramfs generation.
+First, install the `dropbear-initramfs` package. Note that we are passing the `--no-install-recommends` argument here, as we don't want it to install `cryptsetup` and give annoying warnings on every initramfs generation.
 
 ```bash
-apt install --no-install-recommends dropbear
+apt install --no-install-recommends dropbear-initramfs
 ```
 
-Next, create `/etc/dropbear/authorized_keys` and put your ssh keys in there.
+Next, create `/etc/dropbear-initramfs/authorized_keys` and put your ssh keys in there.
 
-You may also edit `/etc/dropbear/config` and adjust it however you like. You can find the list of the options [here](https://linux.die.net/man/8/dropbear). In my opinion, the default is good enough. Some other blog posts may recommend that you change the port to avoid the ssh fingerprint mismatch warning, but I would recommend using a different subdomain to connect to dropbear instead. That way, you can pin Dropbear's fingerprint with SSHFP records. I will write a separate post on this later.
+You may also edit `/etc/dropbear-initramfs/config` and adjust it however you like. You can find the list of the options [here](https://linux.die.net/man/8/dropbear). In my opinion, the default is good enough. Some other blog posts may recommend that you change the port to avoid the ssh fingerprint mismatch warning, but I would recommend using a different subdomain to connect to dropbear instead. That way, you can pin Dropbear's fingerprint with SSHFP records. I will write a separate post on this later.
 
 Then, edit the `/etc/initramfs-tools/initramfs.conf` and add the static IP address for it to use. The format is
 


### PR DESCRIPTION
Dropbear is an SSH client, but since Proxmox is Debian-based, this requires dropbear-initramfs