### PR TITLE
Opt out of Chrome's Topics API

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -5,7 +5,7 @@
   Referrer-Policy : no-referrer
   X-Frame-Options : DENY
   X-XSS-Protection : 0
-  Permissions-Policy : accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), sync-xhr=(), xr-spatial-tracking=()
+  Permissions-Policy : accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), browsing-topics=(), camera=(), clipboard-read=(), display-capture=(), document-domain=(), encrypted-media=(), fullscreen=(), geolocation=(), gyroscope=(), hid=(), idle-detection=(), interest-cohort=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), sync-xhr=(), xr-spatial-tracking=()
   Cross-Origin-Resource-Policy : same-origin
   Cross-Origin-Embedder-Policy : require-corp
   # Cross-Origin-Opener-Policy : same-origin


### PR DESCRIPTION
https://developer.chrome.com/docs/privacy-sandbox/topics/#site-opt-out

This was already implied by `Permissions-Policy: interest-cohort=()` from FLoC, but we should make it explicit.