### PR TITLE
Fix more dead links on Desktop Linux Hardening page

### DIFF
--- a/content/posts/linux/Desktop Linux Hardening.md
+++ b/content/posts/linux/Desktop Linux Hardening.md
@@ -359,7 +359,6 @@ Once again, Kicksecure includes this hardening by default and provides a config 
 
 There are a few things in this config to keep in mind:
 
-- Bluetooth is disabled. Comment out the `install bluetooth` and `install btusb` lines to use Bluetooth.
 - Thunderbolt is disabled. Comment out the `install thunderbolt` line to use Thunderbolt devices.
 - The `cdrom` and `sr_mod` modules are merely _blacklisted_ (can still be loaded at runtime with `modprobe`). If you have no intention to ever use CD&#8209;ROM devices, they should be _disabled_ by *un*commenting the respective `install` lines. ([More about how this works on the ArchWiki](https://wiki.archlinux.org/title/Kernel_module#Using_files_in_/etc/modprobe.d/_2))
 - Apple filesystems are disabled. While generally fine on non&#8209;Apple systems, if you are using an Apple device you **must** check the filesystem of your EFI partition and comment out the relevant `install` line, otherwise your Linux install will not boot. For example, comment out the `install hfsplus` line if your ESP filesystem is HFS+.

--- a/content/posts/linux/Desktop Linux Hardening.md
+++ b/content/posts/linux/Desktop Linux Hardening.md
@@ -198,7 +198,7 @@ Another option is [Kata Containers](https://katacontainers.io/) which masquerade
 
 If you are using Ubuntu LTS, consider subscribing to [Ubuntu Pro](https://ubuntu.com/pro). Canonical currently allows up to 5 machines with the free subscription.
 
-With Ubuntu Pro, you gain access to the [The Ubuntu Security Guide]([https://discourse.ubuntu.com/t/ubuntu-advantage-client/21788](https://ubuntu.com/security/certifications/docs/usg)), which allows for easy application of the CIS OpenSCAP profile:
+With Ubuntu Pro, you gain access to the [The Ubuntu Security Guide](https://ubuntu.com/security/certifications/docs/usg), which allows for easy application of the CIS OpenSCAP profile:
 
 ```bash
 sudo ua enable usg
@@ -285,7 +285,7 @@ _This section extensively references [Madaidan's Linux Hardening Guide](https://
 
 _See ["2.2&nbsp;Sysctl"](https://madaidans-insecurities.github.io/guides/linux-hardening.html#sysctl) in Madaidan's guide._
 
-Madaidan recommends that you disable [unprivileged user namespaces](https://www.containerlabs.kubedaily.com/LXC/Linux%20Containers/User_namespaces.html) due to the [significant attack surface for privilege escalation](https://madaidans-insecurities.github.io/linux.html#kernel). However, some software such as Podman and LXC relies on unprivileged user namespaces. If you wish to use such software, do not disable `kernel.unprivileged_userns_clone`.
+Madaidan recommends that you disable [unprivileged user namespaces](https://github.com/sangam14/CloudNativeLab/blob/master/LXC/Linux%20Containers/User_namespaces.md) due to the [significant attack surface for privilege escalation](https://madaidans-insecurities.github.io/linux.html#kernel). However, some software such as Podman and LXC relies on unprivileged user namespaces. If you wish to use such software, do not disable `kernel.unprivileged_userns_clone`.
 
 If you are using Kicksecure or Whonix, most of this hardening is included by default. If you are using Debian, you should consider [morphing it into Kicksecure](https://www.kicksecure.com/wiki/Debian). On other distributions, you can copy the [configuration files from Kicksecure](https://github.com/Kicksecure/security-misc/tree/master/usr/lib/sysctl.d) into `/etc/sysctl.d/` (but note that these configurations do not disable unprivileged user namespaces).
 


### PR DESCRIPTION
- Fix two more dead links on the Desktop Linux Hardening page indicated in #229 
- Remove the advisory about `30_security-misc.conf` disabling Bluetooth, as this behavior was changed in [this commit](https://github.com/Kicksecure/security-misc/commit/13b4ddbb627d2279b41d1dcbe5c8ce1ac384b088) (the associated pull request for that commit provides the context for this change)