### PR TITLE
Fix grammar errors in Lokinet post and in other Qubes posts

### DIFF
--- a/content/posts/qubes/Firewalling with MirageOS on Qubes OS.md
+++ b/content/posts/qubes/Firewalling with MirageOS on Qubes OS.md
@@ -39,7 +39,7 @@ qvm-create \
   your_template_name
 ``` 
 
-Don't worry if the TemplateVM doesn't launch - we don't need it to.
+Don't worry if the TemplateVM doesn't launch --- we don't need it to.
 
 ### Disposable Template
 
@@ -58,7 +58,7 @@ qvm-features your_disposable_template_name qubes-firewall 1
 qvm-features your_disposable_template_name no-default-kernelopts 1
 ``` 
 
-Your disposable templates should now launch and shutdown properly.
+Your disposable templates should now launch and shut down properly.
 
 ### Disposable FirewallVMs
 

--- a/content/posts/qubes/Using Lokinet on Qubes OS.md
+++ b/content/posts/qubes/Using Lokinet on Qubes OS.md
@@ -11,11 +11,11 @@ author: Tommy
 
 **Before we start...**
 
-This post should not be considered an endorsement of Lokinet in any shape or form. Lokinet is currently not in a good state - it has not had a public release since 2022, and most free public exit nodes have gone offline. According to the developers, they are doing major rewrites of the code, and it should not be used in production at the moment.
+This post should not be considered an endorsement of Lokinet in any shape or form. Lokinet is currently not in a good state --- it has not had a public release since 2022, and most free public exit nodes have gone offline. According to the developers, they are doing major rewrites of the code, and it should not be used in production at the moment.
 
 ## Creating the TemplateVM
 
-Currently, the Lokinet client only seem to work well with Debian-based distributions. This means that our template will have to be one of the Debian-based ones. Personally, I use [this script](https://github.com/TommyTran732/QubesOS-Scripts/blob/main/debian-gnome/debian-gnome.sh) to trim down the Debian GNOME template and convert it to KickSecure. KickSecure reduces the attack surface of Debian with a substantial set of hardening configurations, and a nice feature to go with an anonymity network like Lokinet is [Boot Clock Randomization](https://www.kicksecure.com/wiki/Boot_Clock_Randomization) which helps defend against [time-based denonymization attacks](https://www.whonix.org/wiki/Time_Attacks).
+Currently, the Lokinet client seems to work well with only Debian-based distributions. This means that our template will have to be one of the Debian-based ones. Personally, I use [this script](https://github.com/TommyTran732/QubesOS-Scripts/blob/main/debian-gnome/debian-gnome.sh) to trim down the Debian GNOME template and convert it to Kicksecure. Kicksecure reduces the attack surface of Debian with a substantial set of hardening configurations, and a nice feature to go with an anonymity network like Lokinet is [Boot Clock Randomization](https://www.kicksecure.com/wiki/Boot_Clock_Randomization) which helps defend against [time-based denonymization attacks](https://www.whonix.org/wiki/Time_Attacks).
 
 Start by creating the bind directories for Lokinet's configurations:
 
@@ -31,14 +31,14 @@ curl --proxy http://127.0.0.1:8082 https://deb.oxen.io/pub.gpg | sudo tee /usr/s
 echo "deb [signed-by=/usr/share/keyrings/oxen.gpg] https://deb.oxen.io $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/oxen.list
 ```
 
-Next, `lokinet` and `resolvconf`. `lokinet-gui` has was very buggy when I tested it inside my VM, so I recommend only installing the daemon. `resolvconf` is used by the Lokinet init script but for is not declared as a dependency for some reason, so you have to manually install it as well:
+Next, `lokinet` and `resolvconf`. `lokinet-gui` was very buggy when I tested it inside my VM, so I recommend installing only the daemon. `resolvconf` is used by the Lokinet init script but is not declared as a dependency for some reason, so you have to manually install it as well:
 
 ```bash
 sudo apt update
 sudo apt install lokinet-gui resolvconf
 ```
 
-To work around the problem where Qubes override the DNS configuration at boot, create `/etc/systemd/system/lokinet-dns-fix.service` with the following content:
+To work around the problem where Qubes overrides the DNS configuration at boot, create `/etc/systemd/system/lokinet-dns-fix.service` with the following content:
 
 ```
 [Unit]
@@ -74,7 +74,7 @@ sudo shutdown now
 
 Create an AppVM based on the TemplateVM you have just created. Set `sys-firewall` (or whatever FirewallVM you have connected to your `sys-net`) as the net qube. If you do not have such FirewallVM, use `sys-net` as the net qube.
 
-Edit the `/etc/loki/loki.net` and add the exit node you want to use. At the moment, the only free exit node that I am aware of is `euroexit.loki`:
+Edit `/etc/loki/loki.net` and add the exit node you want to use. At the moment, the only free exit node that I am aware of is `euroexit.loki`:
 
 ```
 [network]

--- a/content/posts/qubes/Using Split GPG and Split SSH on Qubes OS.md
+++ b/content/posts/qubes/Using Split GPG and Split SSH on Qubes OS.md
@@ -13,15 +13,15 @@ This post will go over setting up Split GPG, then setting up Split SSH with the 
 
 Follow the official Qubes OS [documentation](https://www.qubes-os.org/doc/split-gpg/) to set this up.
 
-Note that if you already have a PGP key with a passphrase, you can remove it by installing `pinentry-gtk` to `vault`'s TemplateVM, then do `gpg2 --edit-key <key_id>` and `passwd` to set an empty passphrase. The default non-graphical pinentry will just make an infinite loop and will not allow you to set an empty passphrase.
+Note that if you already have a PGP key with a passphrase, you can remove it by installing `pinentry-gtk` to `vault`'s TemplateVM, then run `gpg2 --edit-key <key_id>` and `passwd` to set an empty passphrase. The default non-graphical pinentry will just make an infinite loop and will not allow you to set an empty passphrase.
 
 ## Split SSH
 
-This part is based on the Qubes Community's [guide](https://github.com/Qubes-Community/Contents/blob/master/docs/configuration/split-ssh.md); however, I will deviate from it to use the PGP keys for SSH instead of generating a new key pair.
+This part is based on the Qubes Community's [guide](https://forum.qubes-os.org/t/split-ssh/19060); however, I will deviate from it to use the PGP keys for SSH instead of generating a new key pair.
 
 ### In `dom0`
 
-- Create `/etc/qubes-rpc/policy/qubes.SshAgent` with `@anyvm @anyvm ask,default_target=vault` as the content. Since the keys ar not passphrase protected, you should **not** set the policy to allow.
+- Create `/etc/qubes-rpc/policy/qubes.SshAgent` with `@anyvm @anyvm ask,default_target=vault` as the content. Since the keys are not passphrase protected, you should **not** set the policy to allow.
 
 ### In `vault` AppVM
 - Add `enable-ssh-support` to the end of `~/.gnupg/gpg-agent.conf`


### PR DESCRIPTION
- Fix grammar errors in recently updated Lokinet post
- Update link to Qubes community guide on Split SSH so that it points to the [newer version hosted on their forum](https://forum.qubes-os.org/t/announcement-qubes-community-project-has-been-migrated-to-the-forum/20367) (The current link directs the reader to this new version.)
- Convert hyphens to em dashes where appropriate
- Lowercase the 's' in Kicksecure to reflect how it is spelled on their official website
- Make grammar changes otherwise not noted above