### PR TITLE
Remove link to archived Kicksecure repository for AppArmor profiles

### DIFF
--- a/content/posts/linux/Choosing Your Desktop Linux Distribution.md
+++ b/content/posts/linux/Choosing Your Desktop Linux Distribution.md
@@ -102,6 +102,6 @@ Fedora Workstation and Silverblue's European counterpart. These are rolling rele
 
 Some of its features include Tor Stream Isolation, [keystroke anonymization](https://www.whonix.org/wiki/Keystroke_Deanonymization#Kloak), [boot clock randomization](https://www.kicksecure.com/wiki/Boot_Clock_Randomization), [encrypted swap](https://github.com/Whonix/swap-file-creator), hardened boot parameters, and hardened kernel settings. One downside of Whonix is that it still inherits outdated packages with lots of downstream patching from Debian.
 
-Future versions of Whonix will likely include [full system AppArmor policies](https://github.com/Whonix/apparmor-profile-everything) and a [sandbox app launcher](https://www.whonix.org/wiki/Sandbox-app-launcher) to fully confine all processes on the system.
+Future versions of Whonix will likely include [full system AppArmor policies](https://forums.whonix.org/t/apparmor-d-full-set-of-apparmor-profiles-1500-profiles/17389/2) and a [sandbox app launcher](https://www.whonix.org/wiki/Sandbox-app-launcher) to fully confine all processes on the system.
 
 Although Whonix is best used [in conjunction with Qubes](https://www.whonix.org/wiki/Qubes/Why_use_Qubes_over_other_Virtualizers), Qubes-Whonix has [various disadvantages](https://forums.whonix.org/t/qubes-whonix-security-disadvantages-help-wanted/8581) when compared to other hypervisors.

--- a/content/posts/linux/Choosing Your Desktop Linux Distribution.md
+++ b/content/posts/linux/Choosing Your Desktop Linux Distribution.md
@@ -102,6 +102,4 @@ Fedora Workstation and Silverblue's European counterpart. These are rolling rele
 
 Some of its features include Tor Stream Isolation, [keystroke anonymization](https://www.whonix.org/wiki/Keystroke_Deanonymization#Kloak), [boot clock randomization](https://www.kicksecure.com/wiki/Boot_Clock_Randomization), [encrypted swap](https://github.com/Whonix/swap-file-creator), hardened boot parameters, and hardened kernel settings. One downside of Whonix is that it still inherits outdated packages with lots of downstream patching from Debian.
 
-Future versions of Whonix will likely include [full system AppArmor policies](https://forums.whonix.org/t/apparmor-d-full-set-of-apparmor-profiles-1500-profiles/17389/2) and a [sandbox app launcher](https://www.whonix.org/wiki/Sandbox-app-launcher) to fully confine all processes on the system.
-
 Although Whonix is best used [in conjunction with Qubes](https://www.whonix.org/wiki/Qubes/Why_use_Qubes_over_other_Virtualizers), Qubes-Whonix has [various disadvantages](https://forums.whonix.org/t/qubes-whonix-security-disadvantages-help-wanted/8581) when compared to other hypervisors.

--- a/content/posts/linux/Desktop Linux Hardening.md
+++ b/content/posts/linux/Desktop Linux Hardening.md
@@ -178,6 +178,7 @@ Note that, unlike Android, traditional desktop Linux distributions typically do 
 You can make your own AppArmor profiles, SELinux policies, [bubblewrap](https://github.com/containers/bubblewrap) profiles, and [seccomp](https://docs.kernel.org/userspace-api/seccomp_filter.html) blacklists to have better confinement of applications. This is an advanced and sometimes tedious task, but there are various projects you could use as reference:
 
 - [Krathalan’s AppArmor profiles](https://github.com/krathalan/apparmor-profiles)
+- [roddhjav's AppArmor profiles](https://github.com/roddhjav/apparmor.d)
 - [noatsecure’s SELinux templates](https://github.com/noatsecure/hardhat-selinux-templates)
 - [Seirdy’s bubblewrap scripts](https://sr.ht/~seirdy/bwrap-scripts)
 

--- a/content/posts/linux/Desktop Linux Hardening.md
+++ b/content/posts/linux/Desktop Linux Hardening.md
@@ -175,7 +175,7 @@ Note that, unlike Android, traditional desktop Linux distributions typically do 
 
 ### Making Your Own Policies/Profiles
 
-You can make your own AppArmor profiles, SELinux policies, [bubblewrap](https://github.com/containers/bubblewrap) profiles, and [seccomp](https://docs.kernel.org/userspace-api/seccomp_filter.html) blacklist to have better confinement of applications. This is an advanced and sometimes tedious task, but there are various projects you could use as reference:
+You can make your own AppArmor profiles, SELinux policies, [bubblewrap](https://github.com/containers/bubblewrap) profiles, and [seccomp](https://docs.kernel.org/userspace-api/seccomp_filter.html) blacklists to have better confinement of applications. This is an advanced and sometimes tedious task, but there are various projects you could use as reference:
 
 - [Krathalan’s AppArmor profiles](https://github.com/krathalan/apparmor-profiles)
 - [noatsecure’s SELinux templates](https://github.com/noatsecure/hardhat-selinux-templates)

--- a/content/posts/linux/Desktop Linux Hardening.md
+++ b/content/posts/linux/Desktop Linux Hardening.md
@@ -177,7 +177,6 @@ Note that, unlike Android, traditional desktop Linux distributions typically do 
 
 You can make your own AppArmor profiles, SELinux policies, [bubblewrap](https://github.com/containers/bubblewrap) profiles, and [seccomp](https://docs.kernel.org/userspace-api/seccomp_filter.html) blacklist to have better confinement of applications. This is an advanced and sometimes tedious task, but there are various projects you could use as reference:
 
-- [Kicksecure's apparmor-profile-everything](https://github.com/Kicksecure/apparmor-profile-everything)
 - [Krathalan’s AppArmor profiles](https://github.com/krathalan/apparmor-profiles)
 - [noatsecure’s SELinux templates](https://github.com/noatsecure/hardhat-selinux-templates)
 - [Seirdy’s bubblewrap scripts](https://sr.ht/~seirdy/bwrap-scripts)


### PR DESCRIPTION
- Remove link to archived Kicksecure repo for AppArmor profiles on the Desktop Linux Hardening post
  - The Readme of the archived repo states that `apparmor.d` will _maybe_ replace `apparmor-profile-everything`. Kicksecure's [documentation](https://www.kicksecure.com/wiki/Apparmor.d) on `apparmor.d` states that the project is "still in development [...] Not yet available for users." The [website](https://apparmor.pujol.io/) for `apparmor.d` states that the project "is still in its early development." As it stands, I think that there's little reason for this link to remain.
  - Closes #229 
- In the Whonix section of the Choosing Your Desktop Linux Distribution post, replace link to archived repo with a link to a Whonix forum post about the future of `apparmor.d` support in Whonix