### PR TITLE
Update link to kernel module config

### DIFF
--- a/content/posts/linux/Desktop Linux Hardening.md
+++ b/content/posts/linux/Desktop Linux Hardening.md
@@ -347,7 +347,7 @@ Further reading:
 
 _See ["2.5.2&nbsp;Blacklisting kernel modules"](https://madaidans-insecurities.github.io/guides/linux-hardening.html#kasr-kernel-modules) in Madaidan's guide._
 
-On distributions other than Whonix and Kicksecure, you can copy the configuration file from [secureblue's repository](https://github.com/secureblue/secureblue/blob/live/config/files/usr/etc/modprobe.d/blacklist.conf) into `/etc/modprobe.d/`.
+On distributions other than Whonix and Kicksecure, you can copy the configuration file from [secureblue's repository](https://github.com/secureblue/secureblue/blob/live/files/system/usr/etc/modprobe.d/blacklist.conf) into `/etc/modprobe.d/`.
 
 There are a few things in this config to keep in mind:
 


### PR DESCRIPTION
- On the Desktop Linux Hardening post, update link to secureblue's kernel module blacklist as the file path was changed in this [commit](https://github.com/secureblue/secureblue/commit/0c1551df09728f2b63d2b43131bdb97433ceddac#diff-4d6e67a040e23f1a4f580d36c21754968b0f247a48c3e791313ccb1503bc26ce)