### PR TITLE
Update link to kernel module config (again)

### DIFF
--- a/content/posts/linux/Desktop Linux Hardening.md
+++ b/content/posts/linux/Desktop Linux Hardening.md
@@ -347,7 +347,7 @@ Further reading:
 
 _See ["2.5.2&nbsp;Blacklisting kernel modules"](https://madaidans-insecurities.github.io/guides/linux-hardening.html#kasr-kernel-modules) in Madaidan's guide._
 
-On distributions other than Whonix and Kicksecure, you can copy the configuration file from [secureblue's repository](https://github.com/secureblue/secureblue/blob/live/files/system/usr/etc/modprobe.d/blacklist.conf) into `/etc/modprobe.d/`.
+On distributions other than Whonix and Kicksecure, you can copy the configuration file from [secureblue's repository](https://github.com/secureblue/secureblue/blob/live/files/system/etc/modprobe.d/blacklist.conf) into `/etc/modprobe.d/`.
 
 There are a few things in this config to keep in mind:
 


### PR DESCRIPTION
- On the Desktop Linux Hardening post, update link to secureblue's kernel module blacklist as the file path was changed in this [commit](https://github.com/secureblue/secureblue/commit/3fb96ece1070e710c31f0842472df5d65d589925#diff-0841639188dd6d6ac324e660beb2d98fa7efdec2e68a3aeee8041d60dbeb62d8)