### PR TITLE
Recommend Molly’s SOCKS proxy rather than the Signal TLS proxy

### DIFF
--- a/content/posts/proxies/Update your Signal TLS Proxy.md
+++ b/content/posts/proxies/Update your Signal TLS Proxy.md
@@ -21,6 +21,6 @@ My Docker Compose setup can be found [here](https://github.com/ArcticFoxes-net/S
 
 Currently, we believe Signal’s TLS Proxies are an incomplete solution to the problems they try to solve. Instead, we recommend using Orbot in conjunction with [Molly](https://molly.im), an alternative Signal client which natively supports SOCKS proxies, to fully tunnel your Signal traffic over the Tor network.
 
-## Sources
+## Attributions (not endorsements)
 
 - [A Warning About Signal Proxies in Iran and Other Oppressive Countries - Privacy Guides](https://www.privacyguides.org/articles/2022/10/15/warning-about-signal-proxies/)


### PR DESCRIPTION
Closes Issue #363, recommends Molly's SOCKS proxy instead of the Signal TLS proxy