### PR TITLE
Stop recommending Whonix and recommend secureblue the most

### DIFF
--- a/content/posts/linux/Choosing Your Desktop Linux Distribution/index.md
+++ b/content/posts/linux/Choosing Your Desktop Linux Distribution/index.md
@@ -51,7 +51,7 @@ Here is a quick, non-authoritative list of distributions we recommend over other
 
 ### SecureBlue
 
-[SecureBlue](https://secureblue.dev/) is the best traditional desktop Linux distribution for privacy and security. It provides hardened operating system images based on Fedora Atomic Desktops. While they do additional parties of trust (SecureBlue, GitHub infrastructure, BlueBuild, Negativo, etc), their images are substantially hardened and not easily replicated by hand. There are several very interesting packages maintained by SecureBlue as well:
+[SecureBlue](https://secureblue.dev/) is the best traditional desktop Linux operating system for privacy and security. It provides hardened operating system images based on Fedora Atomic Desktops. While they do additional parties of trust (SecureBlue, GitHub infrastructure, BlueBuild, Negativo, etc), their images are substantially hardened and not easily replicated by hand. There are several very interesting packages maintained by SecureBlue as well:
 - [Trivalent](https://github.com/secureblue/Trivalent), a hardened chromium desktop build with patches from GrapheneOS's [Vanadium](https://github.com/GrapheneOS/Vanadium).
 - [Hardened Malloc](https://github.com/secureblue/fedora-extras/tree/live/hardened_malloc). SecureBlue packages GrapheneOS's memory allocator and enables it system wide, including for Flatpak applications.
 


### PR DESCRIPTION
Kicksecure is the sister project to Whonix, and

https://discuss.grapheneos.org/d/12764-thoughts-on-security-of-kicksecure-debian-based-linux-distribution/28

> Secureblue has been around for a tiny fraction of the time Kicksecure but has done far more and has a roadmap of doing much more than they already do. Kicksecure removed most of the hardening they provided, is based on a distribution that's a terrible starting point for it and does not have the privacy or… expertise to do much. The person who was adding most of the hardening to Kicksecure left and isn't going to be active in the project again. The lead developer of Kicksecure has views and methods incompatible with providing good privacy or security. It's a stagnant project not doing anything significant. 

> Kicksecure spreads a bunch of misinformation on their website and began spreading misinformation about GrapheneOS after dropping it. Dropping an important security feature and denying it worked properly or was useful because they're angry… shows a lot about the project. They also could have avoided repeatedly attacking and spreading misinformation about GrapheneOS. 

At this point, I think routing Fedora Workstation through Whonix Gateway on QubesOS could be more private and secure than using Whonix Workstation. Using GrapheneOS’s VPN killswitch to route everything through Tor, may also be a step up from Whonix’s overall (lack of) privacy and security.
